### PR TITLE
Hey, I added a setting for hiding gnome-terminal Menubar by default.

### DIFF
--- a/ubuntutweak/mainwindow.py
+++ b/ubuntutweak/mainwindow.py
@@ -470,6 +470,7 @@ class MainWindow(gtk.Window):
             "Jonathan Lumb <jonolumb@gmail.com>",
             "Stepan Martiyanov <martiyanov@gmail.com>",
             "muzuiget <muzuiget@gmail.com>",
+            "DaNmarner <danmarner@gmail.com>",
             ])
         about.set_copyright("Copyright © 2007-2010 TualatriX")
         about.set_wrap_license(True)

--- a/ubuntutweak/modules/gnomesettings.py
+++ b/ubuntutweak/modules/gnomesettings.py
@@ -33,6 +33,7 @@ from ubuntutweak.common.systeminfo import module_check
 from ubuntutweak.common.config import TweakSettings
 from ubuntutweak.common.factory import WidgetFactory
 from ubuntutweak.utils import icon
+from ubuntutweak.conf.gconfsetting import GconfSetting
 
 log = logging.getLogger("Gnome")
 
@@ -92,6 +93,17 @@ class Gnome(TweakModule):
                                          label=_("Enable user switching whilst screen is locked."),
                                          enable_reset=True,
                                          key="user_switch_enabled"),
+            ))
+        self.add_start(box, False, False, 0)
+
+        current_terminal_profile_key = GconfSetting('/apps/gnome-terminal/global/default_profile')
+        current_terminal_profile = current_terminal_profile_key.get_value()
+        default_show_menubar_key = '/apps/gnome-terminal/profiles/%s/default_show_menubar' % current_terminal_profile
+        box = ListPack(_("Terminal"), (
+                    WidgetFactory.create("GconfCheckButton", 
+                                         label=_("Display menubar when Terminal starts up (for current profile)"),
+                                         enable_reset=True,
+                                         key=default_show_menubar_key),
             ))
         self.add_start(box, False, False, 0)
 


### PR DESCRIPTION
I had this use case where most of the time the menubar on Terminal does nothing but occupying space, so I disabled it in gconf-editor and told myself: hey, I should put this into ubuntu-tweak so next time I don't have to look for that option in gconf-editor that hard.

So here it is. I'm a first-timer so I'm not sure if you have any preference on which branch to contribute to. Take a look and merge if you like it!
