### PR TITLE
fixing program crashed when cleaning old kernels

### DIFF
--- a/ubuntutweak/janitor/oldkernel_plugin.py
+++ b/ubuntutweak/janitor/oldkernel_plugin.py
@@ -87,7 +87,7 @@ class OldKernelPlugin(JanitorPlugin):
         c1, c2 = self.current_kernel_version.split('-')
         p1, p2 = version.split('-')
         if c1 == p1:
-            if int(c2) > int(p2):
+            if int(c2[:6]) > int(p2[:6]):
                 return True
             else:
                 return False


### PR DESCRIPTION
when rc version kernel is installed， oldkernel_plugin.py will crash in function _compare_kernel_version:
            if int(c2) > int(p2):

reason: c2 or p2 might be format as  "030500rc1"

so just change above line as:

```
        if int(c2[:6]) > int(p2[:6]):
```
