### PR TITLE
Remove unused IN.INT_MAX import, unavailable as of recent Python packages

### DIFF
--- a/ubuntutweak/policykit/dbusproxy.py
+++ b/ubuntutweak/policykit/dbusproxy.py
@@ -19,10 +19,6 @@
 import dbus
 import logging
 
-from IN import INT_MAX
-
-MAX_DBUS_TIMEOUT = INT_MAX / 1000.0
-
 log = logging.getLogger("DbusProxy")
 
 SHOWED = False


### PR DESCRIPTION
One of the top crashes on errors.ubuntu.com for Ubuntu 13.04 at the moment is a crash in ubuntu-tweak because the latest Python packages no longer allow importing IN.INT_MAX.  In practice this symbol is hardly ever needed anyway, and in this case the value being calculated from it was not used by ubuntu-tweak, so it's simplest to just remove it.
