### PR TITLE
Launchpad bug 1172760 fix.

### DIFF
--- a/ubuntutweak/tweaks/theme.py
+++ b/ubuntutweak/tweaks/theme.py
@@ -63,7 +63,7 @@ class Theme(TweakModule):
                             values=valid_icon_themes,
                             enable_reset=True)
 
-        if system.CODENAME == 'quantal':
+        if system.CODENAME == 'quantal' or system.CODENAME == 'raring':
             window_theme_label, window_theme_combox, window_theme_reset_button = WidgetFactory.create('ComboBox',
                             label=self.utext_window_theme,
                             key='org.gnome.desktop.wm.preferences.theme',


### PR DESCRIPTION
Fixed launchpad bug 1172760. Method selection can be improved since gsettings backend also work in ubuntu 12.04.2.
